### PR TITLE
Add ``python:`` expressions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,12 @@ Changes
 2.0 (unreleased)
 ----------------
 
-- Add ``python:`` expressions. Needed for cases where property callbacks not
-  accept ``widget`` and ``data`` keyword arguments, e.g. ``datatype``.
-  [rnix]
+**Breaking changes:**
 
-- Fix signature of ``yafowil.yaml.tests.test_vocab``. Property callbacks always
-  gets passed ``widget`` and ``data`` as of yafowil 3.0.
+- Add ``python:`` expressions. Needed for cases where property callbacks not
+  accept ``widget`` and ``data`` keyword arguments, e.g. ``datatype``. This is
+  necessary because ``callable_value`` function in yafowil 3.0 no longer calls
+  callable without arguments as fallback.
   [rnix]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,15 @@
 Changes
 =======
 
-1.3.2 (unreleased)
-------------------
+2.0 (unreleased)
+----------------
+
+- Add ``python:`` expressions. Needed for cases where property callbacks not
+  accept ``widget`` and ``data`` keyword arguments, e.g. ``datatype``.
+  [rnix]
 
 - Fix signature of ``yafowil.yaml.tests.test_vocab``. Property callbacks always
-  gets passed ``widget`` and ``data`` as of yafowil 3.0.0.
+  gets passed ``widget`` and ``data`` as of yafowil 3.0.
   [rnix]
 
 

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -2,7 +2,7 @@ License
 =======
 
 Copyright (c) 2010-2021, BlueDynamics Alliance, Austria, Germany, Switzerland
-Copyright (c) 2021, Yafowil Contributors
+Copyright (c) 2021-2022, Yafowil Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ def read_file(name):
         return f.read()
 
 
-version = '1.3.2.dev0'
-shortdesc = 'YAFOWIL - YAML-/ JSON-parser for widget trees.'
+version = '2.0.dev0'
+shortdesc = 'YAFOWIL - YAML/JSON-parser for widget trees.'
 longdesc = '\n\n'.join([read_file(name) for name in [
     'README.rst',
     'CHANGES.rst',

--- a/src/yafowil/yaml/__init__.py
+++ b/src/yafowil/yaml/__init__.py
@@ -1,2 +1,3 @@
-from yafowil.yaml.parser import YAMLParser
-from yafowil.yaml.parser import parse_from_YAML
+from yafowil.yaml.parser import YAMLParser  # noqa
+from yafowil.yaml.parser import parse_from_YAML  # noqa
+from yafowil.yaml.parser import python_expression_globals  # noqa

--- a/src/yafowil/yaml/sphinx.rst
+++ b/src/yafowil/yaml/sphinx.rst
@@ -131,10 +131,22 @@ strings, access to a rendering context and pointers to callables.
     by calling given message factory.
 
 ``expr:``
-    If definition value starts with ``expr:``, a callback wrapper is created
-    which gets executed each time the widget tree gets rendered. For security
-    reasons, only rendering ``context``, ``widget`` and ``data`` are available
+    If definition value starts with ``expr:``, a yafowil callback wrapper gets
+    created, accepting ``widget`` and ``data`` keyword arguments, which is
+    executed when the widget tree is processed. For security reasons, only
+    rendering ``context``, ``widget`` and ``data`` are available
     in expressions.
+
+``python:``
+    If definition value starts with ``python:`` it gets evaluated as plain
+    python expression. This is useful for the rare cases where yafowil or one
+    of it's addons expects a callable not accepting ``widget`` and ``data``
+    as arguments, like ``datatype`` does. By default, these expressions get an
+    empty globals dictionary. Python expression globals can be customized
+    either globally by adding values to ``yafowil.yaml.python_expression_globals``
+    or per parser run by passing ``expression_globals`` to ``YAMLParser``
+    constructor respective ``parse_from_YAML`` function. Parser specific globals
+    take precedence over globally defined ones.
 
 ``context``
     If definition value starts with ``context``, rendering context is used to
@@ -149,7 +161,9 @@ Define rendering context
 ------------------------
 
 A rendering context has to be provided. Refering to the form description
-example above, this may look like::
+example above, this may look like:
+
+.. code-block:: pycon
 
     >>> class FormRenderingContext(object):
     ...
@@ -176,7 +190,9 @@ Create Message Factory
 
 Unless no others are registered one want to use message factories from
 ``pyramid.i18n`` or ``zope.i18nmessageid``. See refering documentation for
-details. Here we create a dummy message factory::
+details. Here we create a dummy message factory:
+
+.. code-block:: pycon
 
     >>> message_factory = lambda x: x
 
@@ -187,15 +203,21 @@ Creating YAFOWIL-Forms form YAML-Files
 To create a yafowil widget tree from YAML, use ``yafowil.yaml.parse_from_YAML``.
 This accepts also JSON file files ending with ``.json``.
 To adress a specific pyhton package path prefix the filename with
-``my.module:``::
+``my.module:``:
+
+.. code-block:: pycon
 
     >>> import yafowil.loader
     >>> from yafowil.yaml import parse_from_YAML
 
     >>> rendering_context = FormRenderingContext()
-    >>> form = parse_from_YAML('yafowil.yaml:demo_form.yaml',
-    ...                        context=rendering_context,
-    ...                        message_factory=message_factory)
+    >>> expression_globals = {}
+    >>> form = parse_from_YAML(
+    ...     'yafowil.yaml:demo_form.yaml',
+    ...     context=rendering_context,
+    ...     message_factory=message_factory,
+    ...     expression_globals=expression_globals
+    ... )
 
 This results into...::
 


### PR DESCRIPTION
 Needed for cases where property callbacks not accept ``widget`` and ``data`` keyword arguments, e.g. ``datatype``.